### PR TITLE
tools to address orphaned event records

### DIFF
--- a/data_fixes/link_events_to_agents.rb
+++ b/data_fixes/link_events_to_agents.rb
@@ -1,0 +1,18 @@
+require 'archivesspace/client'
+require 'json'
+require 'csv'
+require_relative 'helper_methods.rb'
+
+aspace_staging_login()
+
+
+#read in record and linked_record uri's from CSV
+#fix gsub error by checking that each value is in one set of double quotes
+csv = CSV.parse(File.read("data_fixes/event_agent_links.csv"), :headers => true)
+
+csv.each do |row|
+  record = @client.get(row['uri']).parsed
+  record['linked_agents'] = [{'role' => 'authorizer', 'ref' => row['agent_uri']}]
+  post = @client.post(row['uri'], record.to_json)
+  puts post.body
+end

--- a/data_fixes/link_events_to_agents_and_records.rb
+++ b/data_fixes/link_events_to_agents_and_records.rb
@@ -1,0 +1,19 @@
+require 'archivesspace/client'
+require 'json'
+require 'csv'
+require_relative 'helper_methods.rb'
+
+aspace_staging_login()
+
+
+#read in record and linked_record uri's from CSV
+#fix gsub error by checking that each value is in one set of double quotes
+csv = CSV.parse(File.read("data_fixes/event_missing_both_agent_and_resource.csv"), :headers => true)
+
+csv.each do |row|
+  record = @client.get(row['event_uri']).parsed
+  record['linked_agents'] = [{'role' => 'authorizer', 'ref' => row['agent_uri']}]
+  record['linked_records'] = [{'role' => 'source', 'ref' => row['resource_uri']}]
+  post = @client.post(row['event_uri'], record.to_json)
+  puts post.body
+end

--- a/data_fixes/link_events_to_records.rb
+++ b/data_fixes/link_events_to_records.rb
@@ -1,0 +1,18 @@
+require 'archivesspace/client'
+require 'json'
+require 'csv'
+require_relative 'helper_methods.rb'
+
+aspace_staging_login()
+
+
+#read in record and linked_record uri's from CSV
+#fix gsub error by checking that each value is in one set of double quotes
+csv = CSV.parse(File.read("data_fixes/orphaned_events_links.csv"), :headers => true)
+
+csv.each do |row|
+  record = @client.get(row['uri']).parsed
+  record['linked_records'] = [{'role' => 'source', 'ref' => row['linked_uri']}]
+  post = @client.post(row['uri'], record.to_json)
+  puts post.body
+end


### PR DESCRIPTION
Add resource links; add agent links. The third file adds both at the same time--I realized too late that if an event is missing both an agent and a resource link, it won't save with just either, so this is how one has to do it.