### PR TITLE
Aspace2alma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'archivesspace-client'
+gem 'activesupport'
 gem 'rake'
 gem 'rubocop', require: false
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     archivesspace-client (0.1.11)
@@ -28,6 +33,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
     mini_portile2 (2.6.1)
+    minitest (5.15.0)
     multi_xml (0.6.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -60,6 +66,8 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
 
 PLATFORMS
@@ -67,6 +75,7 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
+  activesupport
   archivesspace-client
   capistrano (~> 3.16)
   capistrano-bundler


### PR DESCRIPTION
looks like activesupport isn't installed;
install using https://rubygems.org/gems/activesupport/versions/5.0.0.1
reference using https://edgeguides.rubyonrails.org/active_support_core_extensions.html