### PR TITLE
Add report output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ authentication-staging.sh
 test.rb
 Gemfile
 Gemfile.lock
+*.csv
+*.xml


### PR DESCRIPTION
Just so that running `git status` is clean, even after running a report.