### PR TITLE
Use the same capistrano version pin for gemfile and deploy.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ gem 'net-ssh'
 gem 'whenever', require: false
 
 group :development do
-  gem "capistrano", "~> 3.16", require: false
+  gem "capistrano", "~> 3.16.0"
   gem "capistrano-bundler"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    airbrussh (1.4.0)
+    airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
     archivesspace-client (0.1.11)
       dry-cli (~> 0.7)
@@ -14,7 +14,7 @@ GEM
       json (~> 2.0)
       nokogiri (~> 1.10)
     ast (2.4.2)
-    capistrano (3.17.0)
+    capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -27,7 +27,7 @@ GEM
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     mime-types (3.4.1)
@@ -82,7 +82,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   archivesspace-client
-  capistrano (~> 3.16)
+  capistrano (~> 3.16.0)
   capistrano-bundler
   net-sftp
   net-ssh

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.17.0"
+lock "~> 3.16.0"
 
 set :application, "aspace_helpers"
 set :repo_url, "https://github.com/pulibrary/aspace_helpers.git"


### PR DESCRIPTION
This allowed me to deploy aspace_helpers via pulbot (along with https://github.com/pulibrary/pulbot/pull/115)