### PR TITLE
fix uri-cid mapping for AC107 spreadsheet

### DIFF
--- a/data_fixes/AC107/cid_uri_mapping.xquery
+++ b/data_fixes/AC107/cid_uri_mapping.xquery
@@ -1,0 +1,9 @@
+xquery version "3.0";
+declare namespace ead = "urn:isbn:1-931666-22-9";
+
+declare variable $EAD as document-node()+ := collection("/Users/heberleinr/Documents/aspace_helpers/data_fixes/AC107/EADs?recurse=yes;select=*.xml")/doc(document-uri(.));
+
+for $c in $EAD//ead:c
+return
+$c/@id || '^' || $c/ead:did/ead:unitid[@type='aspace_uri'] || codepoints-to-string(10)
+


### PR DESCRIPTION
got crosswalk from finding aids; added to spreadsheet with index-match

`INDEX(cid_uri_mapping!$B$2:$B$40000,MATCH(C2,cid_uri_mapping!$A$2:$A$40000,0))`