### PR TITLE
Update schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Run on production at 03:30 am EST or 2:30 am EDT every morning except 
+# Run on production at 03:30 am EST or 2:30 am EDT every morning except
 # Monday (Alma jobs are backed up) or Saturday (ASpace maintenance window)
 every '30 8 * * 2-5,7', roles: [:prod] do
   command "cd /opt/aspace_helpers/current/reports/aspace2alma && bundle exec ruby get_MARCxml.rb"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Run on production at 03:30 am EST or 2:30 am EDT
-every 1.day, at: '08:30 am', roles: [:prod] do
+# Run on production at 03:30 am EST or 2:30 am EDT every morning except 
+# Monday (Alma jobs are backed up) or Saturday (ASpace maintenance window)
+every '30 8 * * 2-5,7', roles: [:prod] do
   command "cd /opt/aspace_helpers/current/reports/aspace2alma && bundle exec ruby get_MARCxml.rb"
 end


### PR DESCRIPTION
Skip Saturday morning (ASpace downtime) and Monday morning (Alma bottleneck). This means changes from Friday will import to Alma on Sunday; changes made on Sunday, if any, will import to Alma on Tuesday.

Closes #460 and #461.