### PR TITLE
More verbose rubocop output in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - ruby/rubocop-check:
-          format: progress
-          label: Inspecting with Rubocop
+      - run: bundle exec rubocop
   test:
     docker:
       - image: cimg/ruby:3.4.2-node


### PR DESCRIPTION
CircleCI's rubocop task does not print rubocop errors to standard output, instead putting them into an XML file.

It's nicer to have just the standard output, so we don't have to go digging for the file.