### PR TITLE
switch to gem dot coop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://gem.coop"
 
 gem 'activesupport'
 gem 'archivesspace-client', github: 'lyrasis/archivesspace-client', ref: 'a4351eb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       archivesspace-client
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop/
   specs:
     actionview (8.0.1)
       activesupport (= 8.0.1)


### PR DESCRIPTION
Let's switch to gem.coop.

This is them: https://gem.coop/

Context: https://www.heise.de/en/news/Who-owns-an-open-source-project-RubyGems-threatens-to-split-10685184.html